### PR TITLE
Fix hardware interface initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Currently this package supports only following F/T sensors:
 - ATI AXIA series
 - ATI Net F/T series
 
-Software was tested with `ATI AXIA80` and `OnRobot HEX-E V2`. Tests on ATI Net F/T
-series sensor are needed.
+Software was tested with `ATI AXIA80` and `OnRobot HEX-E V2` and `ATI Net F/T series`.
 
 ## Installation
 

--- a/net_ft_driver/launch/net_ft_broadcaster.launch.py
+++ b/net_ft_driver/launch/net_ft_broadcaster.launch.py
@@ -149,7 +149,7 @@ def generate_launch_description():
     declared_arguments.append(
         launch.actions.DeclareLaunchArgument(
             name="internal_filter_rate",
-            default_value="false",
+            default_value="0",
             description=(
                 "The internal low pass filter rate, "
                 "refer for specific values to the sensor manuals.",
@@ -159,7 +159,7 @@ def generate_launch_description():
     declared_arguments.append(
         launch.actions.DeclareLaunchArgument(
             name="use_hardware_biasing",
-            default_value="0",
+            default_value="false",
             description="Whether to use built-in sensor zeroing",
         )
     )


### PR DESCRIPTION
### Description

* Updated the launch file parameters to correctly initialize the hardware interface, as seen in the 2 images below. The first is before the change, and the second is after the change. 
![Before_change](https://github.com/gbartyzel/ros2_net_ft_driver/assets/61601578/a2f36a3b-ae50-41a5-baa8-c209f60fa21e)
![After_change](https://github.com/gbartyzel/ros2_net_ft_driver/assets/61601578/abd715ce-9655-403e-b6c3-4a778010bc21)

* Updated the README file to reflect new ATI Net F/T testing 

### How I Tested
I successfully launched and echoed the /force_torque_sensor_broadcaster/wrench. 
