### PR TITLE
Fix RDT rate setting for "ati" sensor type to eliminate latency caused by dropped packets. 

### DIFF
--- a/net_ft_driver/src/hardware_interface.cpp
+++ b/net_ft_driver/src/hardware_interface.cpp
@@ -103,9 +103,16 @@ NetFtHardwareInterface::on_activate(const rclcpp_lifecycle::State& /*previous_st
   std::string use_hardware_biasing = info_.hardware_parameters["use_hardware_biasing"];
   if (driver_->start_streaming()) {
     if (use_hardware_biasing == "True" || use_hardware_biasing == "true") {
-      driver_->set_bias();
+      if (!driver_->set_bias()){
+        RCLCPP_FATAL(kLogger, "Couldn't zero sensor with software bias!");
+        return hardware_interface::CallbackReturn::ERROR;
+      }
     } else {
-      driver_->clear_bias();
+      if (!driver_->clear_bias())
+      {
+        RCLCPP_FATAL(kLogger, "Couldn't clear sensor software bias!");
+        return hardware_interface::CallbackReturn::ERROR;
+      }
     }
     std::unique_ptr<SensorData> data = driver_->receive_data();
     if (data) {

--- a/net_ft_driver/src/hardware_interface.cpp
+++ b/net_ft_driver/src/hardware_interface.cpp
@@ -103,13 +103,12 @@ NetFtHardwareInterface::on_activate(const rclcpp_lifecycle::State& /*previous_st
   std::string use_hardware_biasing = info_.hardware_parameters["use_hardware_biasing"];
   if (driver_->start_streaming()) {
     if (use_hardware_biasing == "True" || use_hardware_biasing == "true") {
-      if (!driver_->set_bias()){
+      if (!driver_->set_bias()) {
         RCLCPP_FATAL(kLogger, "Couldn't zero sensor with software bias!");
         return hardware_interface::CallbackReturn::ERROR;
       }
     } else {
-      if (!driver_->clear_bias())
-      {
+      if (!driver_->clear_bias()) {
         RCLCPP_FATAL(kLogger, "Couldn't clear sensor software bias!");
         return hardware_interface::CallbackReturn::ERROR;
       }

--- a/net_ft_driver/src/interfaces/ati_ft_interface.cpp
+++ b/net_ft_driver/src/interfaces/ati_ft_interface.cpp
@@ -46,7 +46,7 @@ bool AtiFTInterface::set_cgi_variable(const std::string& cgi_name, const std::st
   try {
     curlpp::Cleanup cleanup;
     curlpp::Easy request;
-    std::string xml_url{ "http://" + ip_address_ + "/" + cgi_name + "?" + var_name + "&" + value };
+    std::string xml_url{ "http://" + ip_address_ + "/" + cgi_name + "?" + var_name + "=" + value };
     request.setOpt(new curlpp::options::Url(xml_url));
     request.perform();
     return true;
@@ -76,7 +76,7 @@ bool AtiFTInterface::clear_bias()
 bool AtiFTInterface::set_sampling_rate(int rate)
 {
   rate = std::max(min_sampling_freq_, std::min(rate, max_sampling_freq_));
-  return set_cgi_variable("comm.cgi", "commrdtrate", std::to_string(rate));
+  return set_cgi_variable("comm.cgi", "comrdtrate", std::to_string(rate));
 }
 
 bool AtiFTInterface::set_internal_filter(int rate)


### PR DESCRIPTION
In my tests in #3, it seems like the ATI Net F/T box connected to an Omega85 sensor is not receiving some commands properly.

`rdt_sample_rate` at launch of the `net_ft_driver` has no effect, and the incoming packets are coming in at the maximum allowable RDT rate. For the out-of-the-box configuration for the Net F/T this is 7kHz and results in 500/7000 = 7% good packet throughput with the default `ros2_control` update rate setting of 500Hz.

This PR fixes the `rdt_sample_rate` setting in `ati_ft_interface.cpp`.

Marking this as draft until I work through all the CGI logic and testing to make sure every command will still work (and also get formatting right)