### PR TITLE
fix build with asio 1.36

### DIFF
--- a/net_ft_description/CMakeLists.txt
+++ b/net_ft_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(net_ft_description)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/net_ft_diagnostic_broadcaster/CMakeLists.txt
+++ b/net_ft_diagnostic_broadcaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(net_ft_diagnostic_broadcaster)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/net_ft_driver/CMakeLists.txt
+++ b/net_ft_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(net_ft_driver)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/net_ft_driver/include/net_ft_driver/interfaces/net_ft_interface.hpp
+++ b/net_ft_driver/include/net_ft_driver/interfaces/net_ft_interface.hpp
@@ -117,7 +117,7 @@ protected:
 
   void unpack(uint8_t* buffer);
 
-  asio::io_service io_service_;
+  asio::io_context io_context_;
   asio::ip::udp::socket socket_;
 
   std::string ip_address_;

--- a/net_ft_driver/src/interfaces/net_ft_interface.cpp
+++ b/net_ft_driver/src/interfaces/net_ft_interface.cpp
@@ -50,7 +50,7 @@ constexpr uint32_t kStartStreaming = 0x0002;
 namespace net_ft_driver
 {
 NetFTInterface::NetFTInterface(const std::string& ip_address, int max_sampling_freq)
-  : socket_(io_service_)
+  : socket_(io_context_)
   , ip_address_(ip_address)
   , force_scale_(1.0)
   , torque_scale_(1.0)
@@ -65,7 +65,7 @@ NetFTInterface::NetFTInterface(const std::string& ip_address, int max_sampling_f
   , status_(0)
   , ft_values_({ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 })
 {
-  asio::ip::udp::endpoint endpoint(asio::ip::address_v4::from_string(ip_address), kPort);
+  asio::ip::udp::endpoint endpoint(asio::ip::make_address(ip_address), kPort);
   socket_.open(asio::ip::udp::v4());
   socket_.connect(endpoint);
 


### PR DESCRIPTION
Hi,

This PR fix build with asio 1.36.

`io_service` has been deprecated for at least 9 years (ref. blame https://github.com/boostorg/asio/blame/995eeab56906ab0a1f614602aa0dee9ee88bf8cb/include/boost/asio/io_service.hpp), and removed in boostorg/asio@ec0908c
`from_string` has been deprecated for at least 9 years (ref blame https://github.com/boostorg/asio/blame/b60e92b13ef68dfbb9af180d76eae41d22e19356/include/boost/asio/ip/address.hpp), and removed in boostorg/asio@c0d1cfc

While here, remove a CMake v4 warning about CMake < 3.10